### PR TITLE
Put can also upsert

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ Config options:
 
 - **middleware**: `Array`. _An optional array of Koa middleware_
 
+- **putCanCreate**: `Boolean`. Flag indicating that PUT can create data if it does not exist.  Default is false.
+
 - **swaggerDoc**: `Object`. An object containing the swagger document to be exposed at `/docs`
 
 - **credentials**: `Object`

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Config options:
 
 - **middleware**: `Array`. _An optional array of Koa middleware_
 
-- **putCanCreate**: `Boolean`. Flag indicating that PUT can create data if it does not exist.  Default is false.
+- **isPutUpsert**: `Boolean`. Flag indicating that PUT will function as upsert.  Default is false.
 
 - **swaggerDoc**: `Object`. An object containing the swagger document to be exposed at `/docs`
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@photobox/cruddy-simple",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "Node CRUD API",
   "author": "Photobox",
   "contributors": [

--- a/src/persistence/dynamoDb/index.js
+++ b/src/persistence/dynamoDb/index.js
@@ -24,7 +24,7 @@ const readById = (client, params) => async id => {
   }
 };
 
-const upsert = async (client, params, item) => {
+const upsert = (client, params) => async item => {
   try {
     await client.put({ ...params, Item: item }).promise();
     return Either.Right(item);
@@ -33,14 +33,14 @@ const upsert = async (client, params, item) => {
   }
 };
 
-const create = (client, params, createId) => async item => upsert(client, params, { ...item, id: createId() });
+const create = (client, params, createId) => async item => upsert(client, params)({ ...item, id: createId() });
 
 const update = (client, params) => async (id, item) => {
   const result = await readById(client, params)(id);
 
   if (result.isLeft) return result;
 
-  return upsert(client, params, { ...item, id });
+  return upsert(client, params)({ ...item, id });
 };
 
 const destroy = (client, params) => async id => {
@@ -61,5 +61,6 @@ export default (client, params, createId) => ({
   read: read(client, params),
   readById: readById(client, params),
   update: update(client, params),
+  upsert: upsert(client, params),
   delete: destroy(client, params),
 });

--- a/src/persistence/dynamoDb/index.test.js
+++ b/src/persistence/dynamoDb/index.test.js
@@ -215,6 +215,39 @@ describe('Dynamo DB', () => {
     });
   });
 
+  describe('.upsert', () => {
+    const params = { table: 'hello' };
+
+    it('calls client upsert with the specified item', async () => {
+      const item = { id: 111, name: 'Snape' };
+      const putSpy = jest.fn(() => ({ promise: noop }));
+      const client = { put: putSpy, get: () => ({ promise: () => Promise.resolve({}) }) };
+
+      await DynamoDb(client, params).upsert(item);
+
+      expect(putSpy).toHaveBeenCalledWith({ table: 'hello', Item: { id: 111, name: 'Snape' } });
+    });
+
+    it('returns item client upsert is successful', async () => {
+      const item = { name: 'Snape' };
+      const promiseSpy = () => Promise.resolve(item);
+      const client = { put: () => ({ promise: promiseSpy }) };
+
+      const actual = await DynamoDb(client, params).upsert(item);
+
+      expect(actual).toEqual(Either.Right({ name: 'Snape' }));
+    });
+
+    it('returns error when upsert fails', async () => {
+      const item = { name: 'Snape' };
+      const promiseSpy = () => Promise.reject('Professor Snape is displeased');
+      const client = { put: () => ({ promise: promiseSpy }) };
+      const actual = await DynamoDb(client, params).upsert(item);
+
+      expect(actual).toEqual(Either.Left('Professor Snape is displeased'));
+    });
+  });
+
   describe('.delete', () => {
     const params = { table: 'hello' };
 

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -4,7 +4,7 @@ const NOT_ATTACHED_MESSAGE = 'Route not attached';
 
 const missingPropertyMessage = prop => `Route missing ${prop} property`;
 
-export default (router, db, logger, schema, customRoutes, putCanCreate) => {
+export default (router, db, logger, schema, customRoutes, isPutUpsert) => {
   customRoutes.forEach(route => {
     if (!route.method) {
       logger.error(missingPropertyMessage('method'), route);
@@ -34,7 +34,7 @@ export default (router, db, logger, schema, customRoutes, putCanCreate) => {
 
   router.post('/', post(db, logger));
 
-  if (putCanCreate) {
+  if (isPutUpsert) {
     router.put('/:id', upsert(db, logger));
   } else {
     router.put('/:id', put(db, logger));

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -1,10 +1,10 @@
-import { destroy, get, getAll, health, post, put, schemaMiddleware } from '../services';
+import { destroy, get, getAll, health, post, put, schemaMiddleware, upsert } from '../services';
 
 const NOT_ATTACHED_MESSAGE = 'Route not attached';
 
 const missingPropertyMessage = prop => `Route missing ${prop} property`;
 
-export default (router, db, logger, schema, customRoutes) => {
+export default (router, db, logger, schema, customRoutes, putCanCreate) => {
   customRoutes.forEach(route => {
     if (!route.method) {
       logger.error(missingPropertyMessage('method'), route);
@@ -34,7 +34,11 @@ export default (router, db, logger, schema, customRoutes) => {
 
   router.post('/', post(db, logger));
 
-  router.put('/:id', put(db, logger));
+  if (putCanCreate) {
+    router.put('/:id', upsert(db, logger));
+  } else {
+    router.put('/:id', put(db, logger));
+  }
 
   router.delete('/:id', destroy(db, logger));
 

--- a/src/routes/index.test.js
+++ b/src/routes/index.test.js
@@ -50,7 +50,7 @@ describe('Routes', () => {
     });
   });
 
-  describe('PUT /:id', () => {
+  describe('PUT /:id (normal mode)', () => {
     it('calls router put with /:id and a function', () => {
       const putSpy = jest.fn();
       const router = {
@@ -61,6 +61,22 @@ describe('Routes', () => {
       };
       const db = { read: () => {} };
       routes(router, db, noop, {}, []);
+      expect(putSpy).toHaveBeenCalledWith('/:id', expect.any(Function));
+    });
+  });
+
+  describe('PUT /:id (Upsert mode)', () => {
+    it('calls router upsert with /:id and a function', () => {
+      const putSpy = jest.fn();
+      const router = {
+        get: noop,
+        post: noop,
+        put: putSpy,
+        delete: noop,
+      };
+      const db = {};
+
+      routes(router, db, noop, {}, [], true);
       expect(putSpy).toHaveBeenCalledWith('/:id', expect.any(Function));
     });
   });

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -19,7 +19,7 @@ export default config => {
     logger,
     middleware = [],
     port,
-    putCanCreate,
+    isPutUpsert,
     resource,
     routes: customRoutes = [],
     schema,
@@ -29,7 +29,7 @@ export default config => {
   const app = new Koa();
 
   const koaRouter = new KoaRouter({ prefix: `/${resource}` });
-  const router = routes(koaRouter, db, logger, schema, customRoutes, putCanCreate);
+  const router = routes(koaRouter, db, logger, schema, customRoutes, isPutUpsert);
 
   const validator = new Ajv({ allErrors: true }).compile(schema);
 

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -19,6 +19,7 @@ export default config => {
     logger,
     middleware = [],
     port,
+    putCanCreate,
     resource,
     routes: customRoutes = [],
     schema,
@@ -28,7 +29,7 @@ export default config => {
   const app = new Koa();
 
   const koaRouter = new KoaRouter({ prefix: `/${resource}` });
-  const router = routes(koaRouter, db, logger, schema, customRoutes);
+  const router = routes(koaRouter, db, logger, schema, customRoutes, putCanCreate);
 
   const validator = new Ajv({ allErrors: true }).compile(schema);
 
@@ -47,5 +48,5 @@ export default config => {
   app.use(validate(swaggerDoc));
   app.use(ui(swaggerDoc, '/docs'));
 
-  return app.listen(port, () => logger.info(`INFO: Server running at ${host}`));
+  return app.listen(port, () => logger.info(`INFO: Server running at ${host}:${port}`));
 };


### PR DESCRIPTION
### PUT can create

PUT can now be used to create records via a configuration flag.  Default behaviour is to update.  Check the docs for details.

- [x] Expose Upsert as primary function
- [x] Allow PUT to to upsert instead of update via config

### PR Housekeeping

- [x] Unit Tests
- [x] Updated Documentation
- [x] No Linting Errors/ Warnings
- [ ] Passing Build
